### PR TITLE
arm and aarch64: calculate the VirtualSize of .sbat separately

### DIFF
--- a/gnuefi/crt0-efi-aarch64.S
+++ b/gnuefi/crt0-efi-aarch64.S
@@ -110,7 +110,7 @@ section_table:
 	.long	0xc0000040	// Characteristics (section flags)
 
 	.ascii  ".sbat\0\0\0"
-	.long	_sbat_size		// VirtualSize
+	.long	_sbat_vsize		// VirtualSize
 	.long	_sbat - ImageBase	// VirtualAddress
 	.long	_sbat_size		// SizeOfRawData
 	.long	_sbat - ImageBase	// PointerToRawData

--- a/gnuefi/crt0-efi-arm.S
+++ b/gnuefi/crt0-efi-arm.S
@@ -124,7 +124,7 @@ section_table:
 
 
 	.ascii	".sbat\0\0\0"
-	.long	_sbat_size		// VirtualSize
+	.long	_sbat_vsize		// VirtualSize
 	.long	_sbat - ImageBase	// VirtualAddress
 	.long	_sbat_size		// SizeOfRawData
 	.long	_sbat - ImageBase	// PointerToRawData


### PR DESCRIPTION
Use _sbat_vsize from shim's linker script as the VirtualSize of .sbat.

Signed-off-by: Gary Lin <glin@suse.com>