### PR TITLE
Fix -Wstrict-prototypes warnings

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -187,10 +187,10 @@ endif
 
 ifeq (FreeBSD, $(findstring FreeBSD, $(OS)))
 CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra -Werror \
-           -funsigned-char -fshort-wchar -fno-strict-aliasing \
+           -funsigned-char -fshort-wchar -fno-strict-aliasing -Wstrict-prototypes \
            -ffreestanding -fno-stack-protector
 else
-CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra -Wno-pointer-sign -Werror \
+CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra -Wno-pointer-sign -Wstrict-prototypes -Werror \
            -funsigned-char -fshort-wchar -fno-strict-aliasing \
 	   -ffreestanding -fno-stack-protector -fno-stack-check \
            $(if $(findstring gcc,$(CC)),-fno-merge-all-constants,)

--- a/apps/ctors_dtors_priority_test.c
+++ b/apps/ctors_dtors_priority_test.c
@@ -2,22 +2,22 @@
 #include <efilib.h>
 
 // 101 in init_array, 65434 in ctors
-static void __attribute__((constructor(101))) EFI_NO_TAIL_CALL ctors101() {
+static void __attribute__((constructor(101))) EFI_NO_TAIL_CALL ctors101(void) {
     Print(L"1) ctor with lower numbered priority \r\n");
 }
 
 // 65434 in init_array, 101 in ctors
-static void __attribute__((constructor(65434))) EFI_NO_TAIL_CALL ctors65434() {
+static void __attribute__((constructor(65434))) EFI_NO_TAIL_CALL ctors65434(void) {
     Print(L"2) ctor with higher numbered priority \r\n");
 }
 
 // 101 in fini_array, 65434 in dtors
-static void __attribute__((destructor(101))) EFI_NO_TAIL_CALL dtors101() {
+static void __attribute__((destructor(101))) EFI_NO_TAIL_CALL dtors101(void) {
     Print(L"4) dtor with lower numbered priority \r\n");
 }
 
 // 65434 in fini_array, 101 in dtors
-static void __attribute__((destructor(65434))) EFI_NO_TAIL_CALL dtors65434() {
+static void __attribute__((destructor(65434))) EFI_NO_TAIL_CALL dtors65434(void) {
     Print(L"3) dtor with higher numbered priority \r\n");
 }
 

--- a/inc/efiapi.h
+++ b/inc/efiapi.h
@@ -754,6 +754,7 @@ EFI_STATUS
 typedef
 EFI_STATUS
 (EFIAPI *EFI_RESERVED_SERVICE) (
+    VOID
     );
 
 //


### PR DESCRIPTION
Functions without a prototype are deprecated so fix them. 
Also add -Wstrict-prototypes to Make.defaults.